### PR TITLE
Fix space.computer.json

### DIFF
--- a/en_US/space.computer.json
+++ b/en_US/space.computer.json
@@ -22,7 +22,7 @@
     "The third tab shows the destination, which is selected through coordinates (use the field to input).",
     "",
     "Additionally, various security messages can be displayed:",
-    {"type":"translate","text":"\"chat.spaceship.lowEnergie\""},
+    {"type":"translate","text":"chat.spaceship.lowEnergie"},
     "This means that the computer has too little energy.",
     {"type":"translate","text":"chat.spaceship.open"},
     "This means that the ship's computer room is not 100% sealed.",


### PR DESCRIPTION
all 3 languages seem to have the same text here, but I can verify in English, it is not rendering the proper text, but rather the identifier string. I don't remember enough about text in Java or why this was happening, so I just made it match the other two lines that did show correctly.

Perhaps the other languages should be changed as well?